### PR TITLE
Add win32 support

### DIFF
--- a/software/host/.gitignore
+++ b/software/host/.gitignore
@@ -1,5 +1,9 @@
 *~
 *.o
+*.obj
 ovctl
 libov.so
 libov.dylib
+libov.dll
+libov.exp
+libov.lib

--- a/software/host/LibOV.py
+++ b/software/host/LibOV.py
@@ -13,6 +13,8 @@ if _lpath == '':
 
 if sys.platform == 'darwin':
     _lib_suffix = 'dylib'
+elif sys.platform == 'win32':
+	_lib_suffix = 'dll'
 else:
     _lib_suffix = 'so'
 

--- a/software/host/Makefile.nmake
+++ b/software/host/Makefile.nmake
@@ -1,0 +1,2 @@
+libov.dll:
+	cl fastftdi.c fpgaconfig.c bit_file.c hw_common.c ftdieep.c usb_interp.c gettimeofday.c libusb-1.0.lib /I. /DOV_API_EXPORT /link /DLL /out:libov.dll

--- a/software/host/fastftdi.h
+++ b/software/host/fastftdi.h
@@ -29,7 +29,23 @@
 
 #include <libusb.h>
 #include <stdint.h>
+#ifndef _MSC_VER
 #include <stdbool.h>
+#else
+#define bool int
+#define false 0
+#define true  1
+#endif
+
+#ifdef _WIN32
+  #ifdef OV_API_EXPORT
+    #define OV_API __declspec(dllexport)
+  #else
+    #define OV_API __declspec(dllimport)
+  #endif
+#else
+  #define OV_API
+#endif
 
 typedef enum {
   FTDI_BITMODE_RESET        = 0,
@@ -102,34 +118,34 @@ typedef int (FTDIStreamCallback)(uint8_t *buffer, int length,
  * Public Functions
  */
 
-int FTDIDevice_Open(FTDIDevice *dev);
-void FTDIDevice_Close(FTDIDevice *dev);
-int FTDIDevice_Reset(FTDIDevice *dev);
+OV_API int FTDIDevice_Open(FTDIDevice *dev);
+OV_API void FTDIDevice_Close(FTDIDevice *dev);
+OV_API int FTDIDevice_Reset(FTDIDevice *dev);
 
-int FTDIDevice_SetMode(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_SetMode(FTDIDevice *dev, FTDIInterface interface,
                        FTDIBitmode mode, uint8_t pinDirections,
                        int baudRate);
 
-int FTDIDevice_Write(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_Write(FTDIDevice *dev, FTDIInterface interface,
                      uint8_t *data, size_t length, bool async);
 
-int FTDIDevice_WriteByteSync(FTDIDevice *dev, FTDIInterface interface, uint8_t byte);
-int FTDIDevice_ReadByteSync(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
+OV_API int FTDIDevice_WriteByteSync(FTDIDevice *dev, FTDIInterface interface, uint8_t byte);
+OV_API int FTDIDevice_ReadByteSync(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
 
-int FTDIDevice_ReadStream(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_ReadStream(FTDIDevice *dev, FTDIInterface interface,
                           FTDIStreamCallback *callback, void *userdata,
                           int packetsPerTransfer, int numTransfers);
 
-int FTDIDevice_MPSSE_Enable(FTDIDevice *dev, FTDIInterface interface);
-int FTDIDevice_MPSSE_SetDivisor(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_MPSSE_Enable(FTDIDevice *dev, FTDIInterface interface);
+OV_API int FTDIDevice_MPSSE_SetDivisor(FTDIDevice *dev, FTDIInterface interface,
                                 uint8_t ValueL, uint8_t ValueH);
 
-int FTDIDevice_MPSSE_SetLowByte(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_MPSSE_SetLowByte(FTDIDevice *dev, FTDIInterface interface,
                                 uint8_t data, uint8_t dir);
-int FTDIDevice_MPSSE_SetHighByte(FTDIDevice *dev, FTDIInterface interface,
+OV_API int FTDIDevice_MPSSE_SetHighByte(FTDIDevice *dev, FTDIInterface interface,
                                  uint8_t data, uint8_t dir);
 
-int FTDIDevice_MPSSE_GetLowByte(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
-int FTDIDevice_MPSSE_GetHighByte(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
+OV_API int FTDIDevice_MPSSE_GetLowByte(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
+OV_API int FTDIDevice_MPSSE_GetHighByte(FTDIDevice *dev, FTDIInterface interface, uint8_t *byte);
 
 #endif /* __FASTFTDI_H */

--- a/software/host/fpgaconfig.c
+++ b/software/host/fpgaconfig.c
@@ -68,7 +68,11 @@
 
 #include "fpgaconfig.h"
 #include "bit_file.h"
+
+#ifndef _WIN32
 #include <unistd.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 

--- a/software/host/fpgaconfig.h
+++ b/software/host/fpgaconfig.h
@@ -28,6 +28,22 @@
 
 #include "fastftdi.h"
 
+#ifdef _WIN32
+  #ifdef OV_API_EXPORT
+    #define OV_API __declspec(dllexport)
+  #else
+    #define OV_API __declspec(dllimport)
+  #endif
+#else
+  #define OV_API
+#endif
+
 int FPGAConfig_LoadFile(FTDIDevice *dev, const char *filename);
+
+/*
+ * Public
+ */
+
+OV_API int FPGA_GetConfigStatus(FTDIDevice * dev);
 
 #endif /* __FPGACONFIG_H */

--- a/software/host/ftdieep.c
+++ b/software/host/ftdieep.c
@@ -29,6 +29,10 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
+
 #define FTDI_READ_EEPROM_REQUEST      0x90
 #define FTDI_WRITE_EEPROM_REQUEST     0x91
 

--- a/software/host/gettimeofday.c
+++ b/software/host/gettimeofday.c
@@ -1,0 +1,69 @@
+/*
+ * gettimeofday.c
+ *	  Win32 gettimeofday() replacement
+ *
+ * src/port/gettimeofday.c
+ *
+ * Copyright (c) 2003 SRA, Inc.
+ * Copyright (c) 2003 SKC, Inc.
+ *
+ * Permission to use, copy, modify, and distribute this software and
+ * its documentation for any purpose, without fee, and without a
+ * written agreement is hereby granted, provided that the above
+ * copyright notice and this paragraph and the following two
+ * paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
+ * INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ * DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS
+ * IS" BASIS, AND THE AUTHOR HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+ * SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#include <windows.h>
+
+/* FILETIME of Jan 1 1970 00:00:00. */
+static const unsigned __int64 epoch = 116444736000000000ULL;
+
+/*
+ * timezone information is stored outside the kernel so tzp isn't used anymore.
+ *
+ * Note: this function is not for Win32 high precision timing purpose. See
+ * elapsed_time().
+ */
+int
+gettimeofday(struct timeval * tp, struct timezone * tzp)
+{
+	FILETIME	file_time;
+	SYSTEMTIME	system_time;
+	ULARGE_INTEGER ularge;
+
+	GetSystemTime(&system_time);
+	SystemTimeToFileTime(&system_time, &file_time);
+	ularge.LowPart = file_time.dwLowDateTime;
+	ularge.HighPart = file_time.dwHighDateTime;
+
+	tp->tv_sec = (long) ((ularge.QuadPart - epoch) / 10000000L);
+	tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+
+	return 0;
+}
+
+void usleep(__int64 usec) 
+{ 
+    HANDLE timer; 
+    LARGE_INTEGER ft; 
+
+    ft.QuadPart = -(10*usec); // Convert to 100 nanosecond interval, negative value indicates relative time
+
+    timer = CreateWaitableTimer(NULL, TRUE, NULL); 
+    SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0); 
+    WaitForSingleObject(timer, INFINITE); 
+    CloseHandle(timer); 
+}

--- a/software/host/hw_common.h
+++ b/software/host/hw_common.h
@@ -28,6 +28,15 @@
 
 #include "fastftdi.h"
 
+#ifdef _WIN32
+  #ifdef OV_API_EXPORT
+    #define OV_API __declspec(dllexport)
+  #else
+    #define OV_API __declspec(dllimport)
+  #endif
+#else
+  #define OV_API
+#endif
 
 /*
  * Hardware configuration registers
@@ -55,11 +64,11 @@
  * Public
  */
 
-void HW_Init(FTDIDevice *dev, const char *bitstream);
-void HW_SetSystemClock(FTDIDevice *dev, float mhz);
+OV_API void HW_Init(FTDIDevice *dev, const char *bitstream);
+OV_API void HW_SetSystemClock(FTDIDevice *dev, float mhz);
 
-void HW_ConfigWriteMultiple(FTDIDevice *dev, uint16_t *addrArray,
+OV_API void HW_ConfigWriteMultiple(FTDIDevice *dev, uint16_t *addrArray,
                             uint16_t *dataArray, int count, bool async);
-void HW_ConfigWrite(FTDIDevice *dev, uint16_t addr, uint16_t data, bool async);
+OV_API void HW_ConfigWrite(FTDIDevice *dev, uint16_t addr, uint16_t data, bool async);
 
 #endif // __HW_COMMON_H

--- a/software/host/usb_interp.c
+++ b/software/host/usb_interp.c
@@ -2,7 +2,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include "fastftdi.h"
+#include "usb_interp.h"
 
+#ifdef _MSC_VER
+#define snprintf _snprintf
+#endif
 
 enum {
   HF0_ERR =  0x01, //  Physical layer error
@@ -241,11 +245,12 @@ unsigned char got_start = 0;
 int CStreamCallback (uint8_t *buffer, int length,
 			FTDIProgressInfo *progress, void *userdata) {
   unsigned char *p;
+  FTDIStreamCallback *cb;
   if (!buffer ||  !length) 
     return 0;
   //    printf("CStreamCallback(%p, %d, %p, %p)\n", buffer, length, progress, userdata);
   //  hexdump(buffer, length);
-  FTDIStreamCallback *cb = (FTDIStreamCallback *)userdata;
+  cb = (FTDIStreamCallback *)userdata;
 
   //  printf("packet_buf=%p, packet_buf_len=%d\n", packet_buf, packet_buf_len);
   memcpy(packet_buf + packet_buf_len, buffer, length);

--- a/software/host/usb_interp.h
+++ b/software/host/usb_interp.h
@@ -1,8 +1,7 @@
 /*
- * ftdieep.h - Support for generating EEPROM information for the FT2232H,
- *             using the 93C46 EEPROM.
+ * usb_interp.h - usb packet parsing
  *
- * Copyright (C) 2010 Hector Martin <hector@marcansoft.com>
+ * Copyright (C) 2009 Micah Elizabeth Scott
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +22,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef __FTDIEEP_H
-#define __FTDIEEP_H
+#ifndef __USB_INTERP_H
+#define __USB_INTERP_H
 
 #include "fastftdi.h"
 
@@ -39,11 +38,9 @@
 #endif
 
 /*
- * Public Functions
+ * Public
  */
 
-OV_API int FTDIEEP_CheckAndProgram(FTDIDevice *dev, unsigned int number);
-OV_API int FTDIEEP_SanityCheck(FTDIDevice *dev, bool verbose);
-OV_API int FTDIEEP_Erase(FTDIDevice *dev);
+OV_API void ChandlePacket(unsigned long long ts, unsigned int flags, unsigned char *buf, unsigned int len);
 
-#endif /* __FTDIEEP_H */
+#endif /* __USB_INTERP_H */


### PR DESCRIPTION
Added support for building libov with msvc.

libov.dll can then be used together with the existing python scripts to let it run on a windows platform.