### PR TITLE
warning message when compiling.

### DIFF
--- a/software/host/fpgaconfig.c
+++ b/software/host/fpgaconfig.c
@@ -219,7 +219,7 @@ ConfigBegin(FTDIDevice *dev)
     return err;
 
   // Short delay while the FPGA initializes
-  usleep(10000);
+  sleep(10000);
 
   fprintf(stderr, "FPGA: sending configuration bitstream\n");
 


### PR DESCRIPTION
fpgaconfig.c: In function ‘ConfigBegin’:
fpgaconfig.c:222:3: warning: implicit declaration of function ‘usleep’; did you mean ‘sleep’? [-Wimplicit-function-declaration]
   usleep(10000);
   ^~~~~~
   sleep