### PR TITLE
Avoid conflict with async keyword in Python versions >= 3.5.

### DIFF
--- a/software/host/LibOV.py
+++ b/software/host/LibOV.py
@@ -124,11 +124,11 @@ class FTDIDevice:
             self.__is_open = False
             FTDIDevice_Close(self._dev)
 
-    def write(self, intf, buf, async=False):
+    def write(self, intf, buf, async_=False):
         if not isinstance(buf, bytes):
             raise TypeError("buf must be bytes")
 
-        return FTDIDevice_Write(self._dev, intf, buf, len(buf), async)
+        return FTDIDevice_Write(self._dev, intf, buf, len(buf), async_)
 
     def read(self, intf, n):
         buf = []
@@ -595,7 +595,7 @@ class OVDevice:
                 if self.verbose:
                     print("< %s" % " ".join("%02x" % i for i in msg))
 
-                self.dev.write(FTDI_INTERFACE_A, msg, async=False)
+                self.dev.write(FTDI_INTERFACE_A, msg, async_=False)
 
             service.write = write
     

--- a/software/host/ovctl.py
+++ b/software/host/ovctl.py
@@ -513,7 +513,7 @@ def main():
             print("USB: Error checking EEPROM\n")
             return 1
 
-    dev.dev.write(LibOV.FTDI_INTERFACE_A, b'\x00' * 512, async=False)
+    dev.dev.write(LibOV.FTDI_INTERFACE_A, b'\x00' * 512, async_=False)
 
     try:
         if hasattr(args, 'hdlr'):


### PR DESCRIPTION
Before, with Python 3.7:

````
$ ./ovctl.py -h
  File "./ovctl.py", line 516
    dev.dev.write(LibOV.FTDI_INTERFACE_A, b'\x00' * 512, async=False)
                                                             ^
SyntaxError: invalid syntax
````

After:

````
$ ./ovctl.py -h
usage: ovctl.py [-h] [--pkg PKG] [-l] [--verbose] [--config-only]
````