### PR TITLE
Dandify build.py

### DIFF
--- a/software/fpga/ov3/Makefile
+++ b/software/fpga/ov3/Makefile
@@ -2,8 +2,9 @@ PYTHONPATH := ../migen:../misoc
 export PYTHONPATH
 OVCTL := ../../host/ovctl.py
 BUILD := build
-BITFILE := $(BUILD)/ov3.bit
-FWPKG := $(BUILD)/ov3.fwpkg
+TOP := ov3
+BITFILE := $(BUILD)/$(TOP).bit
+FWPKG := $(BUILD)/$(TOP).fwpkg
 
 PYTHON := python3
 
@@ -15,7 +16,7 @@ $(FWPKG): $(BITFILE)
 	$(PYTHON) -m zipfile -c $@ $< $(BUILD)/map.txt
 
 $(BITFILE): $(PY_FILES)
-	$(PYTHON) build.py build_dir=$(BUILD) build_name=ov3
+	$(PYTHON) build.py -d $(BUILD) -n $(TOP)
 
 clean:
 	rm -rf $(BUILD)/*

--- a/software/fpga/ov3/build.py
+++ b/software/fpga/ov3/build.py
@@ -53,20 +53,21 @@ if __name__ == "__main__":
     plat = Platform()
     top = OV3(plat)
 
-    # Build the register map
-    map_file_path = os.path.join(args.build_dir, "map.txt")
-    open(os.path.join(args.build_dir, "map.txt"), "w").write(gen_mapfile(top))
-
-    # Synthesis, pnr, bitgen, etc.
-    plat.build(top, **mibuild_params)
-
+    # Paths
     bit_file_name = args.build_name + '.bit'
+    map_file_path = os.path.join(args.build_dir, "map.txt")
     bit_file_path = os.path.join(args.build_dir, bit_file_name)
     fwpack_file_path = os.path.join(args.build_dir, args.build_name + '.fwpack')
 
+    # Build the register map
+    open(map_file_path, "w").write(gen_mapfile(top))
+
+    # Run the FPGA toolchain to build the bit file
+    plat.build(top, **mibuild_params)
+
     # Generate fwpack
     if args.generate_fwpack and os.path.isfile(bit_file_path):
-        with zipfile.ZipFile(fwpack_file_path, 'w') as pack:
+        with zipfile.ZipFile(fwpack_file_path, 'w', compression=zipfile.ZIP_DEFLATED) as pack:
             with pack.open('map.txt', 'w') as dst, open(map_file_path, 'rb') as src:
                 shutil.copyfileobj(src, dst)
             with pack.open(bit_file_name, 'w') as dst, open(bit_file_path, 'rb') as src:

--- a/software/fpga/ov3/build.py
+++ b/software/fpga/ov3/build.py
@@ -1,6 +1,20 @@
 from ovplatform.ov3 import Platform
 from ovhw.top import OV3
 import sys
+import argparse
+import os
+import json
+import zipfile
+import shutil
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument('-d', '--build-dir', default='build', help='Override build directory.')
+    p.add_argument('-n', '--build-name', default='ov3', help='Override build name.')
+    p.add_argument('-p', '--generate-fwpack', action='store_true', default=False, help='Generate FWPack after build finishes.')
+    p.add_argument('-m', '--mibuild-params', default='{}', type=json.loads, help='Extra mibuild parameters (in JSON).')
+    return p.parse_args()
 
 
 def gen_mapfile(ov3_mod):
@@ -24,11 +38,36 @@ def gen_mapfile(ov3_mod):
 
 
 if __name__ == "__main__":
+    args = parse_args()
+
+    mibuild_params = {
+        'build_dir': args.build_dir,
+        'build_name': args.build_name,
+    }
+
+    if len(args.mibuild_params) != 0:
+        mibuild_params.update(args.mibuild_params)
+
+    os.makedirs(args.build_dir, exist_ok=True)
+
     plat = Platform()
     top = OV3(plat)
 
     # Build the register map
-    # FIXME: build dir should come from command line arg
-    open("build/map.txt", "w").write(gen_mapfile(top))
+    map_file_path = os.path.join(args.build_dir, "map.txt")
+    open(os.path.join(args.build_dir, "map.txt"), "w").write(gen_mapfile(top))
 
-    plat.build(top, **dict(arg.split('=') for arg in sys.argv[1:]))
+    # Synthesis, pnr, bitgen, etc.
+    plat.build(top, **mibuild_params)
+
+    bit_file_name = args.build_name + '.bit'
+    bit_file_path = os.path.join(args.build_dir, bit_file_name)
+    fwpack_file_path = os.path.join(args.build_dir, args.build_name + '.fwpack')
+
+    # Generate fwpack
+    if args.generate_fwpack and os.path.isfile(bit_file_path):
+        with zipfile.ZipFile(fwpack_file_path, 'w') as pack:
+            with pack.open('map.txt', 'w') as dst, open(map_file_path, 'rb') as src:
+                shutil.copyfileobj(src, dst)
+            with pack.open(bit_file_name, 'w') as dst, open(bit_file_path, 'rb') as src:
+                shutil.copyfileobj(src, dst)


### PR DESCRIPTION
Some highlights:

- Fully switched to argparse.
- Now the build directory should be completely relocatable by using the `-d`/`--build-dir`. No more hardcoded map file path.
- The script is now able to generate the `.fwpack` file on its own. This makes build setup on Windows easier since using Makefile on Windows isn't as easy as it was on linux.
- Raw mibuild parameters can still be specified as a single-line JSON by using `-m`/`--mibuild-params`. Adding a dedicated command line option for a mibuild parameter is also very easily doable thanks to argparse.